### PR TITLE
Configure casa-test images to use a UTF-8-aware locale

### DIFF
--- a/share/docker/casa-test/centos-7.4/Dockerfile
+++ b/share/docker/casa-test/centos-7.4/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM centos:7.4.1708
 
+# Use a UTF-8-aware locale (C.UTF-8 is not available on CentOS).
+ENV LANG=en_GB.utf8
+
 # Install system dependencies
 RUN yum -y update --security && \
     yum -y install \

--- a/share/docker/casa-test/ubuntu-12.04/Dockerfile
+++ b/share/docker/casa-test/ubuntu-12.04/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:12.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 # Install system dependencies
 # WARNING: it is necessary to call apt-get install for each packages to 
 # avoid the 101th package issue

--- a/share/docker/casa-test/ubuntu-14.04/Dockerfile
+++ b/share/docker/casa-test/ubuntu-14.04/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:14.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 # Install system dependencies
 # WARNING: it is necessary to call apt-get install for each packages to 
 # avoid the 101th package issue

--- a/share/docker/casa-test/ubuntu-16.04/Dockerfile
+++ b/share/docker/casa-test/ubuntu-16.04/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:16.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 # copy a software-only mesa libGL in /usr/local/lib
 COPY libGL.so.1 /usr/local/lib/libGL.so.1
 COPY libglapi.so.0 /usr/local/lib/libglapi.so.0

--- a/share/docker/casa-test/windows-7-32/Dockerfile
+++ b/share/docker/casa-test/windows-7-32/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:14.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 ENV WINECMD=wine
 ENV WINEARCH=win32
 ENV WINEPREFIX=/casa/wine32

--- a/share/docker/casa-test/windows-7-64/Dockerfile
+++ b/share/docker/casa-test/windows-7-64/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:14.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 ENV WINECMD=wine64
 ENV WINEARCH=win64
 ENV WINEPREFIX=/casa/wine64


### PR DESCRIPTION
This should allow programs running in casa-distro containers to use non-ASCII characters.