### PR TITLE
Remove the pre-commit check for added large files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: fix-encoding-pragma
-    -   id: check-added-large-files
 
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9


### PR DESCRIPTION
We actually need to include large files, e.g. a 35 MiB libGL binary.