### PR TITLE
Use a UTF-8 locale in casa-test:ubuntu-18.04

### DIFF
--- a/share/docker/casa-test/ubuntu-18.04/Dockerfile
+++ b/share/docker/casa-test/ubuntu-18.04/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ubuntu:18.04
 
+# Use a minimal UTF-8-aware locale.
+ENV LANG=C.UTF-8
+
 # copy a software-only mesa libGL in /usr/local/lib
 COPY libGL.so.1 /usr/local/lib/libGL.so.1
 COPY libglapi.so.0 /usr/local/lib/libglapi.so.0


### PR DESCRIPTION
Looks like I forgot to set a UTF-8 locale for Ubuntu 18.04 in e5b438d992b16ce343bf25e44820cdb2fb97d735