### PR TITLE
Fix the path of the home share directory to avoid conflicts

### DIFF
--- a/python/casa_distro/__init__.py
+++ b/python/casa_distro/__init__.py
@@ -33,7 +33,7 @@ def share_directories():
     if default_build_workflow_repository is not None:
         share_directories.append(osp.join(default_build_workflow_repository,
                                           'share'))
-    share_directories += [osp.join(osp.expanduser('~'), '.config',
+    share_directories += [osp.join(osp.expanduser('~'), '.local', 'share',
                                    'casa-distro')]
     share_directories = [d for d in share_directories if os.path.isdir(d)] \
         + [share_directory]

--- a/python/casa_distro/environment.py
+++ b/python/casa_distro/environment.py
@@ -197,10 +197,16 @@ def iter_distros():
     with the "directory" item added.
     """
     for share_directory in share_directories():
-        for root, dirs, files in os.walk(share_directory):
-            if 'casa_distro.json' in files:
-                distro = json.load(open(osp.join(root, 'casa_distro.json')))
-                distro['directory'] = osp.dirname(osp.dirname(root))
+        distro_dir = osp.join(share_directory, 'distro')
+        if not osp.isdir(distro_dir):
+            continue
+        for basename in os.listdir(distro_dir):
+            casa_distro_json = osp.join(distro_dir, basename,
+                                        'host', 'conf', 'casa_distro.json')
+            if osp.isfile(casa_distro_json):
+                with open(casa_distro_json) as f:
+                    distro = json.load(f)
+                distro['directory'] = osp.join(distro_dir, basename)
                 yield distro
 
 


### PR DESCRIPTION
`~/.config/casa-distro` used to be considered a share directory, as a result `casa_distro setup` tries to interpret any `casa_distro.json` that is there as a distro, and fails because these JSONs do not contained the required keys.

As a side not, maybe we should not use `os.walk` but simply `os.listdir` in `iter_distros`? (see `iter_distros`: https://github.com/brainvisa/casa-distro/blob/3.0/python/casa_distro/environment.py#L193-L204)

I fixed the issue by making `~/.local/share/casa-distro` a share directory instead, which is also more consistent with [the XDG spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).