### PR TITLE
Rename CASA_DEFAULT_REPOSITORY to CASA_BASE_DIRECTORY

### DIFF
--- a/python/casa_distro/__init__.py
+++ b/python/casa_distro/__init__.py
@@ -32,9 +32,9 @@ def share_directories():
     """
 
     share_directories = []
-    from casa_distro.defaults import default_build_workflow_repository
-    if default_build_workflow_repository is not None:
-        share_directories.append(osp.join(default_build_workflow_repository,
+    from casa_distro.defaults import default_base_directory
+    if default_base_directory is not None:
+        share_directories.append(osp.join(default_base_directory,
                                           'share'))
     share_directories += [osp.join(osp.expanduser('~'), '.local', 'share',
                                    'casa-distro')]

--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -14,7 +14,7 @@ import sys
 import traceback
 
 from casa_distro.command import command, check_boolean
-from casa_distro.defaults import (default_build_workflow_repository,
+from casa_distro.defaults import (default_base_directory,
                                   default_download_url)
 from casa_distro.environment import (BBIDaily,
                                      casa_distro_directory,
@@ -47,7 +47,7 @@ def download_image(type,
                    filename='casa-{type}-*.{extension}',
                    url=default_download_url + '/{container_type}',
                    output=osp.join(
-                       default_build_workflow_repository, '{filename}'),
+                       default_base_directory, '{filename}'),
                    container_type='singularity',
                    force=False,
                    verbose=True):
@@ -100,7 +100,7 @@ def download_image(type,
 def create_base_image(type,
                       name='casa-{type}-{system}',
                       base=None,
-                      output=osp.join(default_build_workflow_repository,
+                      output=osp.join(default_base_directory,
                                       '{name}.{extension}'),
                       container_type='singularity',
                       memory='8192',
@@ -182,15 +182,15 @@ def create_base_image(type,
     if base is None:
         if type == 'system':
             base = osp.join(
-                default_build_workflow_repository,
+                default_base_directory,
                 '*ubuntu-*.{extension}'.format(extension=origin_extension))
         elif type == 'run':
             base = osp.join(
-                default_build_workflow_repository,
+                default_base_directory,
                 'casa-system-ubuntu-*.{extension}'.format(extension=extension))
         else:
             base = osp.join(
-                default_build_workflow_repository,
+                default_base_directory,
                 'casa-run-ubuntu-*.{extension}'.format(extension=extension))
 
     if not osp.exists(base):
@@ -281,7 +281,7 @@ def create_base_image(type,
 @command
 def publish_base_image(type,
                        image=osp.join(
-                           default_build_workflow_repository,
+                           default_base_directory,
                            'casa-{type}-*.{extension}'),
                        container_type='singularity',
                        verbose=True):
@@ -353,7 +353,7 @@ def create_user_image(
         environment_name=None,
         container_type=None,
         output=osp.join(
-            default_build_workflow_repository,
+            default_base_directory,
             'releases', '{name}{extension}'),
         base_directory=casa_distro_directory(),
         install='yes',

--- a/python/casa_distro/command.py
+++ b/python/casa_distro/command.py
@@ -43,7 +43,7 @@ param_help = {
 {indent}default={base_directory_default}
 {indent}Directory where images and environments are stored. This parameter
 {indent}can be passed on the commandline, or set via the
-{indent}CASA_DEFAULT_REPOSITORY environment variable.''',
+{indent}CASA_BASE_DIRECTORY environment variable.''',
     'type': '''type
 {indent}default={type_default}
 {indent}If given, select environment having the given type.''',

--- a/python/casa_distro/defaults.py
+++ b/python/casa_distro/defaults.py
@@ -4,9 +4,9 @@ from __future__ import absolute_import, division, print_function
 import os
 import os.path as osp
 
-default_build_workflow_repository = os.environ.get('CASA_DEFAULT_REPOSITORY')
-if not default_build_workflow_repository:
-    default_build_workflow_repository = osp.expanduser('~/casa_distro')
+default_base_directory = os.environ.get('CASA_BASE_DIRECTORY')
+if not default_base_directory:
+    default_base_directory = osp.expanduser('~/casa_distro')
 default_repository_server = 'brainvisa.info'
 default_repository_server_directory = 'prod/www/casa-distro'
 default_download_url = 'http://%s/casa-distro' % default_repository_server

--- a/python/casa_distro/environment.py
+++ b/python/casa_distro/environment.py
@@ -287,12 +287,12 @@ _casa_distro_directory = None
 def casa_distro_directory():
     """
     Return the defaut casa_distro directory.
-    Either $CASA_DEFAULT_REPOSITORY or ~/casa_distro.
+    Either $CASA_BASE_DIRECTORY or ~/casa_distro.
     """
     global _casa_distro_directory
 
     if _casa_distro_directory is None:
-        _casa_distro_directory = os.environ.get('CASA_DEFAULT_REPOSITORY')
+        _casa_distro_directory = os.environ.get('CASA_BASE_DIRECTORY')
         if not _casa_distro_directory:
             _casa_distro_directory = osp.expanduser('~/casa_distro')
     return _casa_distro_directory


### PR DESCRIPTION
Rename the `CASA_DEFAULT_REPOSITORY` env var to `CASA_BASE_DIRECTORY` in order to:
- Being consistant with the rest of the documentation that does not talk about  build workflows anymore
- Allow to have a v2 configuration with a different v3 configuration on the same account
