### PR TITLE
Command to create debian package for Singularity

### DIFF
--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -49,8 +49,33 @@ def singularity_deb(system,
                     output='singularity-{version}-{system}.deb',
                     version='3.6.4',
                     go_version='1.13'):
-    '''
-    '''
+    """Create a Debian package to install Singularity.
+    Perform the whole installation process from a rw system and Singularity
+    source. Then put the result in a *.deb file.
+
+    Parameters
+    ----------
+    system
+        Target system. E.g. ubuntu-20.04
+
+    output
+        default={output_default}
+        Location of the resulting Debian package file.
+
+    base
+        Source file use to buld the image. The default value depends on image
+        type and container type.
+
+    version
+        default={version_default}
+        Version of Singularity to use. This must be a valid release version.
+
+    go_version
+        default={go_version_default}
+        Version of Go language to install during Singularity building process.
+        Go language is not included in the final package.
+    """
+
     output = output.format(system=system,
                            version=version)
     tmp = tempfile.mkdtemp(prefix='singularity-deb-')

--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -67,12 +67,14 @@ wget https://dl.google.com/go/go$GO_VERSION.$OS-$ARCH.tar.gz
 tar -C /usr/local -xzvf go$GO_VERSION.$OS-$ARCH.tar.gz
 rm go$GO_VERSION.$OS-$ARCH.tar.gz
 export PATH=/usr/local/go/bin:$PATH
+export GOPATH="$TMP/cache"
 git clone https://github.com/hpcng/singularity.git
 cd singularity
 git checkout v${SINGULARITY_VERSION}
-PATH=$TMP/go/bin:${PATH} GOPATH="$TMP/cache" ./mconfig
-GOPATH="$TMP/cache" make -C builddir dist
-PATH=$TMP/go/bin:${PATH} GOPATH="$TMP/cache" rpmbuild -tb  --nodeps singularity-${SINGULARITY_VERSION}.tar.gz
+./mconfig
+make -C builddir dist
+cd $TMP
+rpmbuild -tb  --nodeps singularity/singularity-${SINGULARITY_VERSION}.tar.gz
 alien --to-deb --scripts $TMP/rpmbuild/RPMS/x86_64/singularity-${SINGULARITY_VERSION}-1.x86_64.rpm
 mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
 ''')
@@ -82,6 +84,7 @@ mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
                                'docker://{}'.format(system.replace('-', ':'))],
                               cwd=tmp)
         subprocess.check_call(['sudo', 'singularity', 'run', '--writable',
+                               '--home', tmp,
                                '--env', 'TMP={}'.format(tmp),
                                '--env', 'SYSTEM={}'.format(system),
                                '--env', 'GO_VERSION={}'.format(go_version),

--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -92,12 +92,14 @@ mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
         # Use singularity to chown because it may be in sudoers
         subprocess.check_call(['sudo', 'singularity', 'run', system,
                                'chown', '--reference', tmp,
-                               tmp_output])
+                               tmp_output],
+                              cwd=tmp)
         shutil.move(tmp_output, output)
     finally:
         # Use singularity to remove temporary directory because it may be in sudoers
         subprocess.check_call(['sudo', 'singularity', 'run', system,
-                               'rm', '-R', tmp])
+                               'rm', '-R', tmp],
+                              cwd=tmp)
 
 
 @command

--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -55,12 +55,13 @@ def singularity_deb(system,
                            version=version)
     tmp = tempfile.mkdtemp(prefix='singularity-deb-')
     try:
-        me = os.getlogin()
         build_sh = osp.join(tmp, 'build.sh')
         open(build_sh, 'w').write('''#!/bin/sh
 set -xe
 apt update -y
-DEBIAN_FRONTEND=noninteractive apt install -y build-essential uuid-dev squashfs-tools libseccomp-dev wget pkg-config git libcryptsetup-dev elfutils rpm alien
+DEBIAN_FRONTEND=noninteractive apt install -y build-essential uuid-dev \
+  squashfs-tools libseccomp-dev wget pkg-config git libcryptsetup-dev \
+  elfutils rpm alien
 cd $TMP
 export OS=linux ARCH=amd64
 wget https://dl.google.com/go/go$GO_VERSION.$OS-$ARCH.tar.gz
@@ -75,7 +76,8 @@ git checkout v${SINGULARITY_VERSION}
 make -C builddir dist
 cd $TMP
 rpmbuild -tb  --nodeps singularity/singularity-${SINGULARITY_VERSION}.tar.gz
-alien --to-deb --scripts $TMP/rpmbuild/RPMS/x86_64/singularity-${SINGULARITY_VERSION}-1.x86_64.rpm
+alien --to-deb --scripts \
+  $TMP/rpmbuild/RPMS/x86_64/singularity-${SINGULARITY_VERSION}-1.x86_64.rpm
 mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
 ''')
         tmp_output = '/tmp/singularity-{}-x86_64.deb'.format(system)
@@ -88,7 +90,8 @@ mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
                                '--env', 'TMP={}'.format(tmp),
                                '--env', 'SYSTEM={}'.format(system),
                                '--env', 'GO_VERSION={}'.format(go_version),
-                               '--env', 'SINGULARITY_VERSION={}'.format(version),
+                               '--env',
+                               'SINGULARITY_VERSION={}'.format(version),
                                system,
                                'sh', build_sh],
                               cwd=tmp)
@@ -99,7 +102,8 @@ mv singularity*.deb /tmp/singularity-$SYSTEM-x86_64.deb
                               cwd=tmp)
         shutil.move(tmp_output, output)
     finally:
-        # Use singularity to remove temporary directory because it may be in sudoers
+        # Use singularity to remove temporary directory because it may be
+        # in sudoers
         subprocess.check_call(['sudo', 'singularity', 'run', system,
                                'rm', '-R', tmp],
                               cwd=tmp)


### PR DESCRIPTION
This PR is related to #147 
The command `casa_distro_admin singularity_deb system=ubuntu-18.04` uses Singularity to create debian package for the installation of Singularity. Efforts have been made to avoid side effects of having big `go` or `buildrpm` directories created in user or root directory. Almost all is done in a temporary directory. Note that this directory grows at least to 2.2 GiB during process. There is still the cache of the base system (taken from DockerHub) that is written in `/root/.singularity/cache`. I cannot really fix that until [a bug in Singularity is fixed](https://github.com/hpcng/singularity/issues/5628).