### PR TITLE
Better customization of BrainVISA server URL

### DIFF
--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -18,9 +18,7 @@ import traceback
 from casa_distro.command import command, check_boolean
 from casa_distro.defaults import (default_base_directory,
                                   default_download_url,
-                                  publish_server,
-                                  publish_login,
-                                  publish_dir)
+                                  publish_url)
 from casa_distro.environment import (BBIDaily,
                                      casa_distro_directory,
                                      iter_environments,
@@ -413,6 +411,15 @@ def publish_base_image(type,
                        container_type='singularity',
                        verbose=True):
     """Upload an image to BrainVISA web site.
+    Upload is done with rsync in the following remote directory:
+
+      {publish_url}
+
+    This directory location can be customized with
+    the following environment variables:
+        BRAINVISA_PUBLISH_LOGIN (default=brainvisa)
+        BRAINVISA_PUBLISH_SERVER (default=brainvisa.info)
+        BRAINVISA_PUBLISH_DIR (default=/var/www/html/brainvisa.info_download)
 
     Parameters
     ----------
@@ -460,12 +467,8 @@ def publish_base_image(type,
     json.dump(metadata, open(metadata_file, 'w'),
               indent=4, separators=(',', ': '))
 
-    subprocess.check_call([
-        'rsync', '-P', '--progress', '--chmod=a+r', metadata_file, image,
-        '{publish_login}@{publish_server}:{publish_dir}/'.format(
-            publish_login=publish_login,
-            publish_server=publish_server,
-            publish_dir=publish_dir)])
+    subprocess.check_call(['rsync', '-P', '--progress', '--chmod=a+r',
+                           metadata_file, image, publish_url])
 
 
 @command
@@ -556,6 +559,15 @@ def create_user_image(
         default={upload_default}
         If "true", "yes" or "1", upload the image on BrainVISA web site.
         If "false", "no" or "0", skip this step
+        Upload is done with rsync in the following remote directory:
+
+          {publish_url}
+
+        This directory location can be customized with
+        the following environment variables:
+          BRAINVISA_PUBLISH_LOGIN (default=brainvisa)
+          BRAINVISA_PUBLISH_SERVER (default=brainvisa.info)
+          BRAINVISA_PUBLISH_DIR (default=/var/www/html/brainvisa.info_download)
     {verbose}
 
     """
@@ -681,12 +693,8 @@ def create_user_image(
                   indent=4, separators=(',', ': '))
 
     if upload:
-        url = '{publish_login}@{publish_server}:{publish_dir}/'.format(
-            publish_login=publish_login,
-            publish_server=publish_server,
-            publish_dir=publish_dir)])
         subprocess.check_call(['rsync', '-P', '--progress', '--chmod=a+r',
-                               metadata_file, output, url])
+                               metadata_file, output, publish_url])
 
 
 @command

--- a/python/casa_distro/admin_commands.py
+++ b/python/casa_distro/admin_commands.py
@@ -17,7 +17,10 @@ import traceback
 
 from casa_distro.command import command, check_boolean
 from casa_distro.defaults import (default_base_directory,
-                                  default_download_url)
+                                  default_download_url,
+                                  publish_server,
+                                  publish_login,
+                                  publish_dir)
 from casa_distro.environment import (BBIDaily,
                                      casa_distro_directory,
                                      iter_environments,
@@ -153,7 +156,7 @@ mv singularity-container*.deb /tmp/singularity-container-$SYSTEM-x86_64.deb
 @command
 def download_image(type,
                    filename='casa-{type}-*.{extension}',
-                   url=default_download_url + '/{container_type}',
+                   url=default_download_url,
                    output=osp.join(
                        default_base_directory, '{filename}'),
                    container_type='singularity',
@@ -457,10 +460,12 @@ def publish_base_image(type,
     json.dump(metadata, open(metadata_file, 'w'),
               indent=4, separators=(',', ': '))
 
-    subprocess.check_call(['rsync', '-P', '--progress', '--chmod=a+r',
-                           metadata_file, image,
-                           'brainvisa@brainvisa.info:prod/www/casa-distro/%s/'
-                           % container_type])
+    subprocess.check_call([
+        'rsync', '-P', '--progress', '--chmod=a+r', metadata_file, image,
+        '{publish_login}@{publish_server}:{publish_dir}/'.format(
+            publish_login=publish_login,
+            publish_server=publish_server,
+            publish_dir=publish_dir)])
 
 
 @command
@@ -676,8 +681,10 @@ def create_user_image(
                   indent=4, separators=(',', ': '))
 
     if upload:
-        url = 'brainvisa@brainvisa.info:prod/www/casa-distro/releases/' \
-            '{container_type}'.format(**metadata)
+        url = '{publish_login}@{publish_server}:{publish_dir}/'.format(
+            publish_login=publish_login,
+            publish_server=publish_server,
+            publish_dir=publish_dir)])
         subprocess.check_call(['rsync', '-P', '--progress', '--chmod=a+r',
                                metadata_file, output, url])
 

--- a/python/casa_distro/command.py
+++ b/python/casa_distro/command.py
@@ -10,6 +10,7 @@ import os.path as osp
 import re
 import sys
 
+from casa_distro.defaults import publish_url
 from casa_distro.info import __version__
 from casa_distro.log import boolean_value
 from casa_distro import six
@@ -151,6 +152,7 @@ def get_doc(command, indent='', format='text'):
     help_vars = dict(executable=executable,
                      casa_version=__version__,
                      base_directory_default=base_directory_default,
+                     publish_url=publish_url,
                      indent='    ')
     help_vars.update(defaults)
     help_vars['base_directory_default'] = base_directory_default

--- a/python/casa_distro/defaults.py
+++ b/python/casa_distro/defaults.py
@@ -12,4 +12,8 @@ publish_server = os.environ.get('BRAINVISA_PUBLISH_SERVER', 'brainvisa.info')
 publish_login = os.environ.get('BRAINVISA_PUBLISH_LOGIN', 'brainvisa')
 publish_dir = os.environ.get('BRAINVISA_PUBLISH_DIR',
                              '/var/www/html/brainvisa.info_download')
+publish_url = '{publish_login}@{publish_server}:{publish_dir}/'.format(
+      publish_login=publish_login,
+      publish_server=publish_server,
+      publish_dir=publish_dir)
 default_download_url = 'https://{}/download'.format(publish_server)

--- a/python/casa_distro/defaults.py
+++ b/python/casa_distro/defaults.py
@@ -7,11 +7,9 @@ import os.path as osp
 default_base_directory = os.environ.get('CASA_BASE_DIRECTORY')
 if not default_base_directory:
     default_base_directory = osp.expanduser('~/casa_distro')
-default_repository_server = 'brainvisa.info'
-default_repository_server_directory = 'prod/www/casa-distro'
-default_download_url = 'http://%s/casa-distro' % default_repository_server
-default_repository_login = 'brainvisa'
-default_environment_type = 'run'
-default_distro = 'opensource'
-default_branch = 'latest_release'
-default_system = 'ubuntu-18.04'
+
+publish_server = os.environ.get('BRAINVISA_PUBLISH_SERVER', 'brainvisa.info')
+publish_login = os.environ.get('BRAINVISA_PUBLISH_LOGIN', 'brainvisa')
+publish_dir = os.environ.get('BRAINVISA_PUBLISH_DIR',
+                             '/var/www/html/brainvisa.info_download')
+default_download_url = 'https://{}/download'.format(publish_server)

--- a/python/casa_distro/environment.py
+++ b/python/casa_distro/environment.py
@@ -553,7 +553,7 @@ def update_container_image(container_type, image_name, url, force=False,
     image_name: str
         image filename (full path)
     url: str
-        pattern ('http://brainvisa.info/casa-distro/{container_type}')
+        pattern (e.g. 'https://brainvisa.info/download/{container_type}')
     force: bool
         download image even if it seems up-to-date
     verbose: file

--- a/python/casa_distro/user_commands.py
+++ b/python/casa_distro/user_commands.py
@@ -341,7 +341,7 @@ def run(type=None, distro=None, branch=None, system=None,
 @command
 def pull_image(distro=None, branch=None, system=None, name=None, type=None,
                image='*', base_directory=casa_distro_directory(),
-               url=default_download_url + '/{container_type}',
+               url=default_download_url,
                force=False, verbose=None):
     '''Update the container images. By default all images that are used by at
     least one environment are updated. There are two ways of selecting the


### PR DESCRIPTION
This PR changes upload directory for the new server organization. It is possible to use `new.brainvisa.info` server for publication by setting `BRAINVISA_PUBLISH_SERVER=new.brainvisa.info`. Removing this variable will switch to `brainvisa.info` (the default).