### PR TITLE
Use singularity build --fakeroot instead of sudo

### DIFF
--- a/python/casa_distro/singularity.py
+++ b/python/casa_distro/singularity.py
@@ -77,14 +77,18 @@ def iter_images(base_directory):
             yield filename
 
 
-def _singularity_build_command(cleanup=True, force=False):
-    build_command = ['sudo']
-    if 'SINGULARITY_TMPDIR' in os.environ:
-        build_command += ['SINGULARITY_TMPDIR='
-                          + os.environ['SINGULARITY_TMPDIR']]
-    if 'TMPDIR' in os.environ:
-        build_command += ['TMPDIR=' + os.environ['TMPDIR']]
+def _singularity_build_command(cleanup=True, force=False, fakeroot=False):
+    build_command = []
+    if not fakeroot:
+        build_command += ['sudo']
+        if 'SINGULARITY_TMPDIR' in os.environ:
+            build_command += ['SINGULARITY_TMPDIR='
+                              + os.environ['SINGULARITY_TMPDIR']]
+        if 'TMPDIR' in os.environ:
+            build_command += ['TMPDIR=' + os.environ['TMPDIR']]
     build_command += ['singularity', 'build', '--disable-cache']
+    if fakeroot:
+        build_command += ['--fakeroot']
     if not cleanup:
         build_command.append('--no-cleanup')
     if force:
@@ -166,7 +170,7 @@ def create_user_image(base_image,
         print(open(recipe.name).read(), file=verbose)
         print('----------------------------------------', file=verbose)
         verbose.flush()
-    build_command = _singularity_build_command(force=force)
+    build_command = _singularity_build_command(force=force, fakeroot=True)
     subprocess.check_call(build_command + [output, recipe.name])
 
 


### PR DESCRIPTION
This avoids having to give root permission to Singularity for building images, which is always good for security. The downside is that you now have to run the following command once, in order to allow Singularity to use the fakeroot mechanism.

```shell
sudo singularity config fakeroot --add $USER
```

Singularity displays an appropriate error message if this has not been done, so I think that we do not even need to make it an option, because this is only used for admin commands anyway (`create_base_image`, `create_user_image`, and indirectly, `bbi_daily`). I will document it in the `bbi_daily` page that I am now finishing to write.