### PR TITLE
Bootstrap brainvisa-cmake at setup time

### DIFF
--- a/share/docker/casa-dev/ubuntu-18.04/dev-environment.sh
+++ b/share/docker/casa-dev/ubuntu-18.04/dev-environment.sh
@@ -28,7 +28,9 @@ if [ -z "$BRAINVISA_BVMAKER_CFG" ]; then
     export BRAINVISA_BVMAKER_CFG="$CASA_CONF/bv_maker.cfg"
 fi
 
-PATH=${PATH}:/usr/local/bin:/casa/brainvisa-cmake/bin
+PATH=${PATH}:/usr/local/bin
+PATH=${PATH}:/casa/host/bootstrap/brainvisa-cmake/bin
+PATH=${PATH}:/casa/bootstrap/brainvisa-cmake
 LD_LIBRARY_PATH=/casa/host/lib:${LD_LIBRARY_PATH}
 export PATH LD_LIBRARY_PATH
 if [ -f "${CASA_BUILD}/bin/bv_env.sh" ] \

--- a/share/docker/casa-dev/ubuntu-18.04/install_casa_dev_components.sh
+++ b/share/docker/casa-dev/ubuntu-18.04/install_casa_dev_components.sh
@@ -22,12 +22,21 @@ sudo git lfs install --system --skip-repo
 # allow attach gdb to a process
 echo "kernel.yama.ptrace_scope = 0" > /etc/sysctl.d/10-ptrace.conf
 
+mkdir /casa/bootstrap
+cat <<EOF > /casa/bootstrap/README.txt
+This directory contains a version of brainvisa-cmake that can be used
+for doing the first compilation in an empty dev environment. It is
+placed last on the PATH in the image, so the version that is compiled as
+part of a BrainVISA build tree will take precedence after the first
+successful build.
+EOF
+
 # Install a version of brainvisa-cmake
-git clone https://github.com/brainvisa/brainvisa-cmake.git \
-          "$CASA_SRC"/development/brainvisa-cmake/master
-mkdir /tmp/brainvisa-cmake
+git clone --depth=1 https://github.com/brainvisa/brainvisa-cmake.git \
+    /tmp/brainvisa-cmake
 cd /tmp/brainvisa-cmake
-cmake -DCMAKE_INSTALL_PREFIX=/casa/brainvisa-cmake $CASA_SRC/development/brainvisa-cmake/master
+cmake -DCMAKE_INSTALL_PREFIX=/casa/bootstrap/brainvisa-cmake .
+make -j$(nproc)
 make install
-cd ..
+cd /tmp
 rm -rf /tmp/brainvisa-cmake


### PR DESCRIPTION
This allows to use a more recent version of brainvisa-cmake than bundled in the image (or a version that matches the branch, if that is available).

~Not fully tested yet~ works for me (although I did not push the resulting `casa-dev` image)