### PR TITLE
Add a software-only libGL in the casa-run-5.3 image

### DIFF
--- a/image-recipes/casa-run/5.3/build_dependencies.sh
+++ b/image-recipes/casa-run/5.3/build_dependencies.sh
@@ -20,6 +20,15 @@ build_dependencies=(
     #
     # cmake
 
+    # Build dependencies of MESA's libGL
+    byacc
+    flex
+    libxcb-randr0-dev
+    libxrandr-dev
+    llvm-dev
+    meson
+    python3-mako
+
     # Build dependencies of MIRCen's fork of openslide
     autoconf
     automake

--- a/image-recipes/casa-run/5.3/build_image.py
+++ b/image-recipes/casa-run/5.3/build_image.py
@@ -66,9 +66,6 @@ def copy_build_files(base_dir, builder):
                       '/usr/local/bin/')
     builder.run_root('chmod a+rx /usr/local/bin/entrypoint')
 
-    # copy a software-only mesa libGL in /usr/local/lib # TODO
-    # builder.copy_root(os.path.join(base_dir, 'mesa'), '/usr/local/lib/')
-
 
 @builder.step
 def apt_dependencies(base_dir, builder):

--- a/image-recipes/casa-run/5.3/install_apt_dependencies.sh
+++ b/image-recipes/casa-run/5.3/install_apt_dependencies.sh
@@ -242,6 +242,7 @@ brainvisa_shared_library_dependencies=(
     libdcmtk16
     libgdk-pixbuf-2.0-0
     libgfortran5
+    libglapi-mesa
     libgl1
     libglib2.0-0
     libglu1-mesa
@@ -249,6 +250,7 @@ brainvisa_shared_library_dependencies=(
     libhdf5-103-1
     libjpeg-turbo8
     libjxr0
+    libllvm14
     libnetcdf19
     libopenjp2-7
     libpng16-16
@@ -284,7 +286,10 @@ brainvisa_shared_library_dependencies=(
     libstdc++6
     libsvm3
     libtiff5
+    libx11-6
+    libxext6
     libxml2
+    libzstd1
 )
 
 # Programs and data that BrainVISA depends on at runtime


### PR DESCRIPTION
We used to ship a software-only libGL in casa-run-5.0 but it was dropped during the upgrade to newer Ubuntu versions. Here it is back for the casa-run-5.3 image, but this time it is compiled during the creation of the image instead of being shipped pre-compiled (it is actually quite fast to compile).

This is part of an attempt to fix https://github.com/brainvisa/casa-distro/issues/321 but a software-only libGL could be useful in other scenarios.

I have built the new images and am ready to push them if you approve this PR :-) 